### PR TITLE
Add INVALID identity state

### DIFF
--- a/schema/v2.yaml
+++ b/schema/v2.yaml
@@ -163,6 +163,7 @@ models:
       enum:
       - '"ACTIVE"'
       - '"INACTIVE"'
+      - '"INVALID"'
       optional: false
       nullable: false
     - field: featureMask


### PR DESCRIPTION
An identity is INVALID if it does not exist (this should never happen) or if it was revoked.